### PR TITLE
Trigger copy & concat tasks when new files are added

### DIFF
--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -168,7 +168,7 @@ class Gulper {
 
   watch () {
     gulp.watch(
-      'src/**/*.*',
+      'src/**/*',
       {cwd: config.get('cwd')},
       e => {
         try {

--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -81,6 +81,10 @@ class Gulper {
         return
       }
 
+      if (!path.match(/\.[0-9a-z]+$/i)) {
+        throw `Error copying path ${path}`;
+      }
+
       let src = path.match(/(\/customers\/.*|.[^\/]*)$/)
       if (src && src[1]) {
         src = src[1]

--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -111,7 +111,7 @@ class Gulper {
       const dest = `${config.get('cwd')}/dist/${base}${src}`
       const dir = nodePath.dirname(dest)
 
-      if (type === 'changed') {
+      if (type === 'changed' || type === 'added') {
         console.log(`Copying ${path}`.cyan)
         const pipe = gulp
           .src(path)
@@ -168,7 +168,8 @@ class Gulper {
 
   watch () {
     gulp.watch(
-      config.get('cwd')+'/src/**/*.*',
+      'src/**/*.*',
+      {cwd: config.get('cwd')},
       e => {
         try {
           this.copy(e, true)
@@ -178,7 +179,8 @@ class Gulper {
       }
     )
     gulp.watch(
-      config.get('cwd')+'/src/config/**',
+      'src/config/**',
+      {cwd: config.get('cwd')},
       e => {
         try {
           this.concat(true)


### PR DESCRIPTION
Fixes #11 

New files added to the source directory will trigger copy & concat tasks.

![new-files-now-working](https://user-images.githubusercontent.com/5134470/48985710-1cb09b00-f0d0-11e8-9f07-f66f1fe1d83b.gif)
