### PR TITLE
Split vendor and commons

### DIFF
--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -20,6 +20,7 @@ class Webpacker {
     this.preparePlugins()
     this.prepareModule()
     this.prepareExternals()
+    this.prepareOptimization()
 
     this.initCompiler()
   }
@@ -149,6 +150,20 @@ class Webpacker {
     this.externals = Object.assign({}, this.config.externals)
   }
 
+  prepareOptimization () {
+    if (!(process.env.NODE_ENV === 'production')) {
+      return
+    }
+
+    // Automatically split vendor and commons
+    // https://twitter.com/wSokra/status/969633336732905474
+    this.optimization = {
+      splitChunks: {
+        chunks: 'all'
+      }
+    }
+  }
+
   initCompiler () {
     let {
       devtool,
@@ -158,6 +173,7 @@ class Webpacker {
       resolveLoader,
       plugins,
       externals,
+      optimization,
       module: _module
     } = this
 
@@ -170,6 +186,7 @@ class Webpacker {
       resolveLoader,
       plugins,
       externals,
+      optimization,
       module: _module
     }
 

--- a/lib/webpack.js
+++ b/lib/webpack.js
@@ -159,7 +159,8 @@ class Webpacker {
     // https://twitter.com/wSokra/status/969633336732905474
     this.optimization = {
       splitChunks: {
-        chunks: 'all'
+        chunks: 'all',
+        automaticNameDelimiter: '@'
       }
     }
   }


### PR DESCRIPTION
Configure `SplitChunksPlugin` on production mode to separate vendors from bundles and reduce the amount of code included in them so that they parse and execute faster.

<img width="1554" alt="Screen Shot 2020-05-17 at 10 04 22 PM" src="https://user-images.githubusercontent.com/5134470/82176699-5bba4980-988c-11ea-9ab0-331024b87557.png">

- [Preview with](https://healthynesting.myshopify.com/?preview_theme_id=77133840433&pb=0)
- Followup to 
  * [zz-driggs/webpack.config.js@ce82f3d0](https://gitlab.com/barrel/zz-driggs-shopify/-/commit/ce82f3d09713fb3940c2b3c479a65df6d8de9a05)
  * [healthynest/theme.liquid@c3623582](https://gitlab.com/barrel/healthynest/-/commit/c36235822af66de38b29b3027bc78a93e2e46f9f)

cc @bengodfrey @wturnerharris 
