### PR TITLE
Mutator pattern check update

### DIFF
--- a/lib/mutator.js
+++ b/lib/mutator.js
@@ -95,19 +95,19 @@ class Mutator {
       let base = ''
       let src = fileName.replace(/(.*)([.]section|[.]template)([.]liquid)/, '$1$3')
 
-      if (/locales/.test(path)) {
+      if (/\/locales/.test(path)) {
         base = 'locales'
       } else if (!/[.]liquid$/.test(fileName)) {
         base = 'assets'
-      } else if (/template/.test(path) && /[.]liquid/.test(fileName)) {
-        if (/templates\/customers/.test(path)) {
+      } else if (/\/templates/.test(path) || /[.]template/.test(path)) {
+        if (/\/templates\/customers/.test(path)) {
           base = 'templates/customers'
         } else {
           base = 'templates'
         }
-      } else if (/section/.test(path)) {
+      } else if (/\/sections/.test(path) || /[.]section/.test(path)) {
         base = 'sections'
-      } else if (/layout/.test(path)) {
+      } else if (/\/layout/.test(path) || /[.]layout/.test(path)) {
         base = 'layout'
       } else {
         base = 'snippets'


### PR DESCRIPTION
Issue: Some module files on a legacy theme had "section" and "template" in some filenames which led to them being incorrectly copied to the `sections` and `templates` folders.

Update mutator to not miscatagorize liquid files with 'template' or 'section' in the filename.
- Checks filename for `/locales` instead of `locales`.
- Checks filename for `/templates` or `.template` instead of `template` and `.liquid`.
- Checks filename for `/section` or `.section` instead of `section`.
- Checks filename for `/layout` or `.layout` instead of `layout`.